### PR TITLE
Remove document from redis storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,10 @@ The message Payload should be like following:
 } 
 ```
 
-The Properties of the published message should be : content_type = application/json. (Note: Make sure this is a property and not a header)
+The Properties of the published message should be : content_type = application/json.
+##### Note
+Make sure this is a property and not a header
+
 The lib will try to get the content from Redis Storage with key and md5 specified in above key and md5.
 
 #### Setup

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ The message Payload should be like following:
     }   
 } 
 ```
-The Properties of the published message should be : content-type = application/json .
+The Properties of the published message should be : content_type = application/json .
 The lib will try to get the content from Redis Storage with key and md5 specified in above key and md5.
 
 #### Setup
@@ -410,7 +410,7 @@ you can use this [Postman collection](jrcc-access-api/jrcc-document-api.postman_
 For body, select form-data and input key value as "file" and select file.
 set the http header to `Content-Type: multipart/form-data`.
 
-![Postman config](docs\postman.body.png)
+![Postman config](docs/postman.body.png)
 
 
 ####if you want to run the sample app using redis and rabbitmq do the following

--- a/README.md
+++ b/README.md
@@ -116,7 +116,9 @@ server.port=5050
 
 #### Description
 
-Using this plugin you can receive JSON format messages from a specified rabbitMq queue(in our program, it is test-doc.0s.x0.q). 
+Using this plugin you can receive JSON format messages from a specified rabbitMq queue(in our program, it is test-doc.0s.x0.q).
+To publish, visit the RabbitMQ Management console (accessible on port 15672), navigate to the `Queues` tab and scroll down to the `Publish message` section.
+
 The message Payload should be like following:
 ```properties
 {
@@ -134,7 +136,8 @@ The message Payload should be like following:
     }   
 } 
 ```
-The Properties of the published message should be : content_type = application/json .
+
+The Properties of the published message should be : content_type = application/json. (Note: Make sure this is a property and not a header)
 The lib will try to get the content from Redis Storage with key and md5 specified in above key and md5.
 
 #### Setup

--- a/jrcc-access-spring-boot-autoconfigure/src/main/java/ca/bc/gov/open/jrccaccess/autoconfigure/plugins/rabbitmq/RabbitMqDocumentInput.java
+++ b/jrcc-access-spring-boot-autoconfigure/src/main/java/ca/bc/gov/open/jrccaccess/autoconfigure/plugins/rabbitmq/RabbitMqDocumentInput.java
@@ -61,9 +61,12 @@ public class RabbitMqDocumentInput {
 		
 		this.documentReadyHandler.handle(content, documentReadyMessage.getTransactionInfo());
 
+                logger.debug("attempting to delete the document from redis storage");
+
                 //when successfully processed, delete the document from redis storage
                 this.redisStorageService.deleteString(storageProperties.getKey());
 
+                logger.info("document successfully deleted from redis storage");
 		logger.info("message successfully acknowledged");
 		MDC.clear();
 	}

--- a/jrcc-access-spring-boot-autoconfigure/src/main/java/ca/bc/gov/open/jrccaccess/autoconfigure/plugins/rabbitmq/RabbitMqDocumentInput.java
+++ b/jrcc-access-spring-boot-autoconfigure/src/main/java/ca/bc/gov/open/jrccaccess/autoconfigure/plugins/rabbitmq/RabbitMqDocumentInput.java
@@ -60,6 +60,10 @@ public class RabbitMqDocumentInput {
 		}
 		
 		this.documentReadyHandler.handle(content, documentReadyMessage.getTransactionInfo());
+
+                //when successfully processed, delete the document from redis storage
+                this.redisStorageService.deleteString(storageProperties.getKey());
+
 		logger.info("message successfully acknowledged");
 		MDC.clear();
 	}

--- a/jrcc-access-spring-boot-autoconfigure/src/main/java/ca/bc/gov/open/jrccaccess/autoconfigure/plugins/rabbitmq/RedisStorageService.java
+++ b/jrcc-access-spring-boot-autoconfigure/src/main/java/ca/bc/gov/open/jrccaccess/autoconfigure/plugins/rabbitmq/RedisStorageService.java
@@ -92,4 +92,19 @@ public class RedisStorageService implements StorageService {
 
 	}
 
+	/**
+	 * Deletes a key/document pair from redis store
+	 * @param key
+	 * @return
+	 */
+	public Boolean deleteString(String key) throws DocumentMessageException {
+
+		try {
+                        this.cacheManager.getCache(accessProperties.getInput().getDocumentType()).evict(key);
+			return true;
+		} catch (RedisConnectionFailureException e) {
+			throw new ServiceUnavailableException("redis service unavailable", e.getCause());
+		}
+
+	}
 }

--- a/jrcc-access-spring-boot-autoconfigure/src/main/java/ca/bc/gov/open/jrccaccess/autoconfigure/plugins/rabbitmq/RedisStorageService.java
+++ b/jrcc-access-spring-boot-autoconfigure/src/main/java/ca/bc/gov/open/jrccaccess/autoconfigure/plugins/rabbitmq/RedisStorageService.java
@@ -103,7 +103,7 @@ public class RedisStorageService implements StorageService {
                         this.cacheManager.getCache(accessProperties.getInput().getDocumentType()).evict(key);
 			return true;
 		} catch (RedisConnectionFailureException e) {
-			throw new ServiceUnavailableException("redis service unavailable", e.getCause());
+			throw new DocumentMessageException("redis service unavailable", e.getCause());
 		}
 
 	}

--- a/jrcc-access-spring-boot-autoconfigure/src/test/java/ca/bc/gov/open/jrccaccess/autoconfigure/plugins/rabbitmq/RedisStorageServiceTests.java
+++ b/jrcc-access-spring-boot-autoconfigure/src/test/java/ca/bc/gov/open/jrccaccess/autoconfigure/plugins/rabbitmq/RedisStorageServiceTests.java
@@ -116,5 +116,12 @@ public class RedisStorageServiceTests {
 		@SuppressWarnings("unused")
 		String expected = sut.getString(MISSING_DOCUMENT, "098A");
 	}
+
+        @Test
+	public void deleteString_with_valid_input_should_return_true() throws DocumentMessageException {
+		Boolean result = sut.deleteString(KEY);
+
+		assertEquals(true, result);
+	}
 	
 }

--- a/jrcc-access-spring-boot-autoconfigure/src/test/java/ca/bc/gov/open/jrccaccess/autoconfigure/plugins/rabbitmq/RedisStorageServiceTests.java
+++ b/jrcc-access-spring-boot-autoconfigure/src/test/java/ca/bc/gov/open/jrccaccess/autoconfigure/plugins/rabbitmq/RedisStorageServiceTests.java
@@ -57,6 +57,7 @@ public class RedisStorageServiceTests {
 	    Mockito.doNothing().when(this.cache).put(Mockito.anyString(), Mockito.eq(VALID));
 	    Mockito.doThrow(RedisConnectionFailureException.class).when(this.cache).put(Mockito.anyString(), Mockito.eq(REDIS_CONNECTION_FAILURE_EXCEPTION));
 	    Mockito.doThrow(RedisConnectionFailureException.class).when(this.cache).get(Mockito.eq(REDIS_CONNECTION_FAILURE_EXCEPTION));
+            Mockito.doThrow(RedisConnectionFailureException.class).when(this.cache).evict(Mockito.eq(REDIS_CONNECTION_FAILURE_EXCEPTION));
 	    Mockito.when(pluginConfig.getDocumentType()).thenReturn("test-doc");
 	    Mockito.when(accessProperties.getInput()).thenReturn(pluginConfig);
 	    Mockito.when(accessProperties.getOutput()).thenReturn(pluginConfig);
@@ -123,5 +124,11 @@ public class RedisStorageServiceTests {
 
 		assertEquals(true, result);
 	}
-	
+
+        @Test(expected = DocumentMessageException.class)
+        public void deleteString_with_invalid_input_should_throw_DocumentMessageException() throws DocumentMessageException {
+                @SuppressWarnings("unused")
+                Boolean result = sut.deleteString(REDIS_CONNECTION_FAILURE_EXCEPTION);
+        }
+
 }


### PR DESCRIPTION
## Overview

This PR addresses https://github.com/bcgov/jrcc-document-access-libs/issues/122

When a message is successfully received then it is removed from the rabbit message queue; however, it is not removed from redis. This PR implements removal of documents from redis as well.

## Screenshots

<img width="212" alt="redis" src="https://user-images.githubusercontent.com/28017034/64896371-5e490d00-d634-11e9-8348-0994615c50ff.PNG">

Shows the document before and after being received (successfully removed from redis).

## Review

@peggy-ntt @alexjoybc 