### PR TITLE
Transaction must have a unique identifier

### DIFF
--- a/jrcc-document-access-libs/src/main/java/ca/bc/gov/open/jrccaccess/libs/TransactionInfo.java
+++ b/jrcc-document-access-libs/src/main/java/ca/bc/gov/open/jrccaccess/libs/TransactionInfo.java
@@ -15,7 +15,7 @@ import java.util.UUID;
  */
 public class TransactionInfo {
 
-	private UUID uuid;
+	private UUID id;
 	/**
 	 * the original sender (organization_
 	 */
@@ -36,7 +36,9 @@ public class TransactionInfo {
 			@JsonProperty("fileName")String fileName, 
 			@JsonProperty("sender")String sender, 
 			@JsonProperty("receivedOn")LocalDateTime receivedOn) {
-		
+
+		this.id = UUID.randomUUID();
+
 		if(sender == null || sender.isEmpty()) throw new IllegalArgumentException("sender");
 		if(fileName == null || fileName.isEmpty()) throw new IllegalArgumentException("fileName");	
 		if(receivedOn == null) throw new IllegalArgumentException("receivedOn");
@@ -44,7 +46,6 @@ public class TransactionInfo {
 		this.sender = sender;
 		this.fileName = fileName;
 		this.receivedOn = receivedOn;
-		this.uuid = UUID.randomUUID();
 	}
 	
 	public String getSender() {
@@ -59,11 +60,11 @@ public class TransactionInfo {
 		return receivedOn;
 	}
 
-	public String getUUIDStr(){return this.uuid.toString();}
+	public UUID getID() { return this.id; }
 	
 	@Override
 	public String toString() {		
-		return	MessageFormat.format("Transaction[{3}] sent from [{0}] on [{1}], fileName [{2}]", this.sender, this.receivedOn.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME), this.fileName,getUUIDStr());
+		return	MessageFormat.format("Transaction[{3}] sent from [{0}] on [{1}], fileName [{2}]", this.sender, this.receivedOn.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME), this.fileName,this.id);
 	}
 	
 }

--- a/jrcc-document-access-libs/src/main/java/ca/bc/gov/open/jrccaccess/libs/TransactionInfo.java
+++ b/jrcc-document-access-libs/src/main/java/ca/bc/gov/open/jrccaccess/libs/TransactionInfo.java
@@ -63,7 +63,7 @@ public class TransactionInfo {
 	
 	@Override
 	public String toString() {		
-		return	MessageFormat.format("Transaction[{3}] sent from [{0}] on [{1}], fileName [{2}]", this.sender, this.receivedOn.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME), this.fileName,this.uuid.toString());
+		return	MessageFormat.format("Transaction[{3}] sent from [{0}] on [{1}], fileName [{2}]", this.sender, this.receivedOn.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME), this.fileName,getUUIDStr());
 	}
 	
 }

--- a/jrcc-document-access-libs/src/main/java/ca/bc/gov/open/jrccaccess/libs/TransactionInfo.java
+++ b/jrcc-document-access-libs/src/main/java/ca/bc/gov/open/jrccaccess/libs/TransactionInfo.java
@@ -14,6 +14,7 @@ import java.time.format.DateTimeFormatter;
  */
 public class TransactionInfo {
 
+	private UUID uuid;
 	/**
 	 * the original sender (organization_
 	 */
@@ -42,7 +43,7 @@ public class TransactionInfo {
 		this.sender = sender;
 		this.fileName = fileName;
 		this.receivedOn = receivedOn;
-
+		this.uuid = UUID.
 	}
 	
 	public String getSender() {

--- a/jrcc-document-access-libs/src/main/java/ca/bc/gov/open/jrccaccess/libs/TransactionInfo.java
+++ b/jrcc-document-access-libs/src/main/java/ca/bc/gov/open/jrccaccess/libs/TransactionInfo.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import java.text.MessageFormat;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.UUID;
 
 /**
  * Represents the transaction information
@@ -43,7 +44,7 @@ public class TransactionInfo {
 		this.sender = sender;
 		this.fileName = fileName;
 		this.receivedOn = receivedOn;
-		this.uuid = UUID.
+		this.uuid = UUID.randomUUID();
 	}
 	
 	public String getSender() {
@@ -57,10 +58,12 @@ public class TransactionInfo {
 	public LocalDateTime getReceivedOn() {
 		return receivedOn;
 	}
+
+	public String getUUIDStr(){return this.uuid.toString();}
 	
 	@Override
 	public String toString() {		
-		return	MessageFormat.format("Transaction sent from [{0}] on [{1}], fileName [{2}]", this.sender, this.receivedOn.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME), this.fileName);
+		return	MessageFormat.format("Transaction[{3}] sent from [{0}] on [{1}], fileName [{2}]", this.sender, this.receivedOn.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME), this.fileName,this.uuid.toString());
 	}
 	
 }

--- a/jrcc-document-access-libs/src/test/java/ca/bc/gov/open/jrccaccess/libs/TransactionInfoTests.java
+++ b/jrcc-document-access-libs/src/test/java/ca/bc/gov/open/jrccaccess/libs/TransactionInfoTests.java
@@ -6,6 +6,7 @@ import java.time.LocalDateTime;
 import java.time.Month;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class TransactionInfoTests {
 
@@ -57,11 +58,8 @@ public class TransactionInfoTests {
 	
 	@Test
 	public void with_valid_input_toString_should_print_valid_message() {
-		
 		TransactionInfo sut = new TransactionInfo("myfile.txt", "me", LocalDateTime.of(2019, Month.FEBRUARY, 1, 10,10,10));
-	
-		assertEquals("Transaction sent from [me] on [2019-02-01T10:10:10], fileName [myfile.txt]", sut.toString());
-		
+		assertTrue(sut.toString().matches("Transaction\\[.*\\] sent from \\[me\\] on \\[2019*-02*-01T10:10:10\\], fileName \\[myfile.txt\\]"));
 	}
 	
 	

--- a/jrcc-document-access-libs/src/test/java/ca/bc/gov/open/jrccaccess/libs/TransactionInfoTests.java
+++ b/jrcc-document-access-libs/src/test/java/ca/bc/gov/open/jrccaccess/libs/TransactionInfoTests.java
@@ -6,7 +6,6 @@ import java.time.LocalDateTime;
 import java.time.Month;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
 public class TransactionInfoTests {
 
@@ -59,7 +58,7 @@ public class TransactionInfoTests {
 	@Test
 	public void with_valid_input_toString_should_print_valid_message() {
 		TransactionInfo sut = new TransactionInfo("myfile.txt", "me", LocalDateTime.of(2019, Month.FEBRUARY, 1, 10,10,10));
-		assertTrue(sut.toString().matches("Transaction\\[.*\\] sent from \\[me\\] on \\[2019*-02*-01T10:10:10\\], fileName \\[myfile.txt\\]"));
+		assertEquals("Transaction["+sut.getUUIDStr()+"] sent from [me] on [2019-02-01T10:10:10], fileName [myfile.txt]",sut.toString());
 	}
 	
 	

--- a/jrcc-document-access-libs/src/test/java/ca/bc/gov/open/jrccaccess/libs/TransactionInfoTests.java
+++ b/jrcc-document-access-libs/src/test/java/ca/bc/gov/open/jrccaccess/libs/TransactionInfoTests.java
@@ -58,7 +58,7 @@ public class TransactionInfoTests {
 	@Test
 	public void with_valid_input_toString_should_print_valid_message() {
 		TransactionInfo sut = new TransactionInfo("myfile.txt", "me", LocalDateTime.of(2019, Month.FEBRUARY, 1, 10,10,10));
-		assertEquals("Transaction["+sut.getUUIDStr()+"] sent from [me] on [2019-02-01T10:10:10], fileName [myfile.txt]",sut.toString());
+		assertEquals("Transaction["+sut.getID()+"] sent from [me] on [2019-02-01T10:10:10], fileName [myfile.txt]",sut.toString());
 	}
 	
 	


### PR DESCRIPTION
When creating a new transactionInfo, a new unique identifier must be set (UUID)

review requested. @sdevalapurkar @alexjoybc 