### PR TITLE
add transaction id to mdc

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,11 +25,12 @@ Add settings into the `application.settings` or `application.yml` file.
  ```properties
  logging.level.root = INFO  
  logging.level.ca.gov.bc = DEBUG
- logging.pattern.console = "%d{yyyy-MM-dd HH:mm:ss} [%thread] %-5level %logger{36} %X{transaction.filename} - %msg%n"
+ logging.pattern.console = "%d{yyyy-MM-dd HH:mm:ss} [%thread] %-5level %logger{36} %X{transaction.filename} %X{transaction.id}- %msg%n"
  ```
 logging.pattern.console property only works if we use Logback logging implementation (the default). The pattern which is needed to be specified also follows the [Logback layout rules](https://logback.qos.ch/manual/layouts.html#ClassicPatternLayout)
 
 %X{transaction.filename} is the java logging MDC key for transaction filename supported in jrcc-document-access-libs.
+%X{transaction.id} is java logging MDC key for transaction id supported in jrcc-document-access-libs.
 
  
  ##### Change settings for input/output plugins - using the following configuration guide for Plugin.

--- a/jrcc-access-spring-boot-autoconfigure/src/main/java/ca/bc/gov/open/jrccaccess/autoconfigure/common/Constants.java
+++ b/jrcc-access-spring-boot-autoconfigure/src/main/java/ca/bc/gov/open/jrccaccess/autoconfigure/common/Constants.java
@@ -9,6 +9,7 @@ public class Constants {
      * Represents Java Logging MDC KEY - filename
      */
     public static final String MDC_KEY_FILENAME="transaction.filename";
+    public static final String MDC_KEY_TRANSACTION_ID="transaction.id";
 
     private Constants() {
         throw new IllegalStateException("Constants class");

--- a/jrcc-access-spring-boot-autoconfigure/src/main/java/ca/bc/gov/open/jrccaccess/autoconfigure/services/DocumentReadyHandler.java
+++ b/jrcc-access-spring-boot-autoconfigure/src/main/java/ca/bc/gov/open/jrccaccess/autoconfigure/services/DocumentReadyHandler.java
@@ -1,11 +1,13 @@
 package ca.bc.gov.open.jrccaccess.autoconfigure.services;
 
+import ca.bc.gov.open.jrccaccess.autoconfigure.common.Constants;
 import ca.bc.gov.open.jrccaccess.libs.DocumentOutput;
 import ca.bc.gov.open.jrccaccess.libs.TransactionInfo;
 import ca.bc.gov.open.jrccaccess.libs.processing.DocumentProcessor;
 import ca.bc.gov.open.jrccaccess.libs.services.exceptions.DocumentMessageException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
 import org.springframework.stereotype.Component;
 
 import java.util.Optional;
@@ -47,6 +49,7 @@ public class DocumentReadyHandler {
 
 		if(transactionInfo == null)
 			throw new IllegalArgumentException("TransactionInfo is required.");
+		MDC.put(Constants.MDC_KEY_TRANSACTION_ID, transactionInfo.getID().toString());
 
 		logger.debug("New document in {}", this.getClass().getName());
 

--- a/jrcc-access-spring-boot-autoconfigure/src/test/java/ca/bc/gov/open/jrccaccess/autoconfigure/services/DocumentReadyHandlerTests.java
+++ b/jrcc-access-spring-boot-autoconfigure/src/test/java/ca/bc/gov/open/jrccaccess/autoconfigure/services/DocumentReadyHandlerTests.java
@@ -10,6 +10,7 @@ import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 
 import java.util.Optional;
+import java.util.UUID;
 
 public class DocumentReadyHandlerTests {
 
@@ -23,22 +24,19 @@ public class DocumentReadyHandlerTests {
 	
 	@Mock
 	private TransactionInfo transactionInfoMock;
-	
-	
-	
+
 	@Before
 	public void init() throws Exception {
 		
 		MockitoAnnotations.initMocks(this);
 		Mockito.doNothing().when(this.documentOutput).send(Mockito.anyString(), Mockito.any());
 		Mockito.when(documentProcessor.processDocument(Mockito.anyString(), Mockito.any())).thenReturn("processed");
-
+		Mockito.when(transactionInfoMock.getID()).thenReturn(UUID.randomUUID());
 	}
 	
 	
 	@Test(expected = Test.None.class )
 	public void when_with_valid_input_no_processor_should_process() throws Exception {
-
 		Optional<DocumentProcessor> documentProcessorOptional = Optional.empty();
 		sut = new DocumentReadyHandler(documentOutput, documentProcessorOptional);
 		sut.handle("awesome content", transactionInfoMock);

--- a/jrcc-access-spring-boot-sample-app/src/main/resources/application.yml
+++ b/jrcc-access-spring-boot-sample-app/src/main/resources/application.yml
@@ -6,8 +6,8 @@ logging:
       gov:
         bc: DEBUG
   pattern:
-    console: "%d{yyyy-MM-dd HH:mm:ss} [%thread] %-5level %logger{36} %X{transaction.filename} - %msg%n"
-    file: "%d{yyyy-MM-dd HH:mm:ss} [%thread] %-5level %logger{36} %X{transaction.filename} - %msg%n"
+    console: "%d{yyyy-MM-dd HH:mm:ss} [%thread] %-5level %logger{36} %X{transaction.filename} %X{transaction.id} - %msg%n"
+    file: "%d{yyyy-MM-dd HH:mm:ss} [%thread] %-5level %logger{36} %X{transaction.filename} %X{transaction.id} - %msg%n"
 bcgov:
   access:
     input:


### PR DESCRIPTION
after adding transactionID to mdc, the log is like:
2019-09-17 12:21:35 [main] INFO  c.b.g.o.j.a.s.DocumentReadyHandler console.txt 03b71622-c2c9-40a3-b744-bf81777a785c - document Transaction[03b71622-c2c9-40a3-b744-bf81777a785c] sent from [console] on [2019-09-17T12:21:35.124], fileName [console.txt] successfully delivered.

Please confirm if we need transactionID in TransactionInfo toString method.