### PR TITLE
Update - Sender Config

### DIFF
--- a/jrcc-access-spring-boot-autoconfigure/src/main/java/ca/bc/gov/open/jrccaccess/autoconfigure/plugins/console/ConsoleInput.java
+++ b/jrcc-access-spring-boot-autoconfigure/src/main/java/ca/bc/gov/open/jrccaccess/autoconfigure/plugins/console/ConsoleInput.java
@@ -9,7 +9,6 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
-import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -56,8 +55,8 @@ public class ConsoleInput implements CommandLineRunner {
 	public void run(String... args) throws Exception {
 		Scanner scanner = new Scanner(System.in);
 
-		if (StringUtils.isBlank(inputConfig.getSender())) {
-			logger.warn("Sender not specified in application.yml, using default value.");
+		if (inputConfig.getSender().equals("unknown")) {
+			logger.warn("Sender not specified in application.yml, using default value of unknown.");
 		}
 		
 		while(scanner.hasNext()) {

--- a/jrcc-access-spring-boot-autoconfigure/src/main/java/ca/bc/gov/open/jrccaccess/autoconfigure/plugins/http/DocumentController.java
+++ b/jrcc-access-spring-boot-autoconfigure/src/main/java/ca/bc/gov/open/jrccaccess/autoconfigure/plugins/http/DocumentController.java
@@ -67,8 +67,8 @@ public class DocumentController implements DocumentApi {
 		DocumentReceivedResponse response = new DocumentReceivedResponse();
 		response.setAcknowledge(true);
 
-		if (StringUtils.isBlank(sender) && StringUtils.isBlank(inputConfig.getSender())) {
-			logger.warn("Sender not specified in application.yml, using default value.");
+		if (StringUtils.isBlank(sender) && inputConfig.getSender().equals("unknown")) {
+			logger.warn("Sender not specified in application.yml, using default value of unknown.");
 		}
 
 		try {

--- a/jrcc-access-spring-boot-autoconfigure/src/main/java/ca/bc/gov/open/jrccaccess/autoconfigure/plugins/sftp/SftpDocumentInput.java
+++ b/jrcc-access-spring-boot-autoconfigure/src/main/java/ca/bc/gov/open/jrccaccess/autoconfigure/plugins/sftp/SftpDocumentInput.java
@@ -12,7 +12,6 @@ import org.slf4j.MDC;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageHeaders;
 import org.springframework.stereotype.Component;
-import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Qualifier;
 
 import javax.websocket.MessageHandler;
@@ -46,8 +45,8 @@ public class SftpDocumentInput implements MessageHandler {
 
         if(message == null) throw new IllegalArgumentException("Message is required.");
 
-        if (StringUtils.isBlank(inputConfig.getSender())) {
-            logger.warn("Sender not specified in application.yml, using default value.");
+        if (inputConfig.getSender().equals("unknown")) {
+            logger.warn("Sender not specified in application.yml, using default value of unknown.");
         }
 
         try {


### PR DESCRIPTION
## Overview

In https://github.com/bcgov/jrcc-document-access-libs/pull/136, there was a change that made it so that the getter of a method returns a default value of the sender (`unknown`) and then we were checking for a blank value and logging a warning upon that condition being met. 

This will no longer ever be the case because the value will not be blank - instead it will be unknown - so the check has been updated to check for the default value instead.

## Review

@peggy-ntt @alexjoybc 