### PR TITLE
SFTP: Display entire config for logging

### DIFF
--- a/jrcc-access-spring-boot-autoconfigure/src/main/java/ca/bc/gov/open/jrccaccess/autoconfigure/plugins/sftp/AutoConfiguration.java
+++ b/jrcc-access-spring-boot-autoconfigure/src/main/java/ca/bc/gov/open/jrccaccess/autoconfigure/plugins/sftp/AutoConfiguration.java
@@ -42,8 +42,14 @@ public class AutoConfiguration {
     public AutoConfiguration(SftpInputProperties sftpInputProperties) {
         this.properties = sftpInputProperties;
 
-        logger.debug("SFTP Configuration:\n");
-        logger.debug(this.properties.formatPublicFields());
+        logger.debug("SFTP Configuration: Host => [{}]", this.properties.getHost());
+        logger.debug("SFTP Configuration: Port => [{}]", this.properties.getPort());
+        logger.debug("SFTP Configuration: Username => [{}]", this.properties.getUsername());
+        logger.debug("SFTP Configuration: Remote Directory => [{}]", this.properties.getRemoteDirectory());
+        logger.debug("SFTP Configuration: Filter Pattern => [{}]", this.properties.getFilterPattern());
+        logger.debug("SFTP Configuration: Cron => [{}]", this.properties.getCron());
+        logger.debug("SFTP Configuration: Max Message Per Poll => [{}]", this.properties.getMaxMessagePerPoll());
+        logger.debug("SFTP Configuration: Known Host File => [{}]", this.properties.getKnownHostFile());
 
     }
 

--- a/jrcc-access-spring-boot-autoconfigure/src/main/java/ca/bc/gov/open/jrccaccess/autoconfigure/plugins/sftp/AutoConfiguration.java
+++ b/jrcc-access-spring-boot-autoconfigure/src/main/java/ca/bc/gov/open/jrccaccess/autoconfigure/plugins/sftp/AutoConfiguration.java
@@ -42,8 +42,8 @@ public class AutoConfiguration {
     public AutoConfiguration(SftpInputProperties sftpInputProperties) {
         this.properties = sftpInputProperties;
 
-        logger.debug("SFTP Configuration: Host => [{}]", this.properties.getHost());
-        logger.debug("SFTP Configuration: Port => [{}]", this.properties.getPort());
+        logger.debug("SFTP Configuration:\n");
+        logger.debug(this.properties.formatPublicFields());
 
     }
 

--- a/jrcc-access-spring-boot-autoconfigure/src/main/java/ca/bc/gov/open/jrccaccess/autoconfigure/plugins/sftp/SftpInputProperties.java
+++ b/jrcc-access-spring-boot-autoconfigure/src/main/java/ca/bc/gov/open/jrccaccess/autoconfigure/plugins/sftp/SftpInputProperties.java
@@ -4,7 +4,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.core.io.ByteArrayResource;
 import org.springframework.core.io.Resource;
-import java.text.MessageFormat;
 
 import javax.validation.constraints.Min;
 
@@ -41,19 +40,6 @@ public class SftpInputProperties {
 	private boolean allowUnknownKeys;
 
 	private String knownHostFile;
-
-	public String formatPublicFields() {
-		return MessageFormat.format(
-			"Host: {0}\n" +
-			"Port: {1}\n" +
-			"Username: {2}\n" +
-			"Remote Directory: {3}\n" +
-			"Filter Pattern: {4}\n" +
-			"Cron: {5}\n" +
-			"Max Message per Poll: {6}\n" +
-			"Known Host File: {7}\n",
-			this.getHost(), this.getPort(), this.getUsername(), this.getRemoteDirectory(), this.getFilterPattern(), this.getCron(), this.getMaxMessagePerPoll(), this.getKnownHostFile());
-	}
 
 	public String getRemoteDirectory() {
 		return remoteDirectory;

--- a/jrcc-access-spring-boot-autoconfigure/src/main/java/ca/bc/gov/open/jrccaccess/autoconfigure/plugins/sftp/SftpInputProperties.java
+++ b/jrcc-access-spring-boot-autoconfigure/src/main/java/ca/bc/gov/open/jrccaccess/autoconfigure/plugins/sftp/SftpInputProperties.java
@@ -4,6 +4,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.core.io.ByteArrayResource;
 import org.springframework.core.io.Resource;
+import java.text.MessageFormat;
 
 import javax.validation.constraints.Min;
 
@@ -40,6 +41,19 @@ public class SftpInputProperties {
 	private boolean allowUnknownKeys;
 
 	private String knownHostFile;
+
+	public String formatPublicFields() {
+		return MessageFormat.format(
+			"Host: {0}\n" +
+			"Port: {1}\n" +
+			"Username: {2}\n" +
+			"Remote Directory: {3}\n" +
+			"Filter Pattern: {4}\n" +
+			"Cron: {5}\n" +
+			"Max Message per Poll: {6}\n" +
+			"Known Host File: {7}\n",
+			this.getHost(), this.getPort(), this.getUsername(), this.getRemoteDirectory(), this.getFilterPattern(), this.getCron(), this.getMaxMessagePerPoll(), this.getKnownHostFile());
+	}
 
 	public String getRemoteDirectory() {
 		return remoteDirectory;


### PR DESCRIPTION
## Overview

This PR addresses https://github.com/bcgov/jrcc-document-access-libs/issues/134

All the config fields were wished to be displayed rather than just the `host` and `port`. With these changes, all the public (non secure) fields specified in the config will be logged in debug mode.

## Review Requests

@alexjoybc @peggy-ntt 