### PR TITLE
Replace sysout with logger

### DIFF
--- a/jrcc-access-spring-boot-autoconfigure/src/main/java/ca/bc/gov/open/jrccaccess/autoconfigure/plugins/console/ConsoleOutput.java
+++ b/jrcc-access-spring-boot-autoconfigure/src/main/java/ca/bc/gov/open/jrccaccess/autoconfigure/plugins/console/ConsoleOutput.java
@@ -34,7 +34,7 @@ public class ConsoleOutput implements DocumentOutput {
 	public void send(String content, TransactionInfo transactionInfo) {
 		logger.info("transactionInfo: {}", transactionInfo);
 		String result = this.prettifier.prettify(content);
-		System.out.println(result);
+		logger.info("Content: " + result);
 	}
 
 }


### PR DESCRIPTION
## Overview

This PR makes a change to try to address this sonarqube complaint (code smell):
https://sonarqube-9wbi3f-tools.pathfinder.gov.bc.ca/component_measures?id=ca.bc.gov.open%3Adocument-access&metric=uncovered_lines&selected=ca.bc.gov.open%3Ajrcc-access-spring-boot-autoconfigure%3Asrc%2Fmain%2Fjava%2Fca%2Fbc%2Fgov%2Fopen%2Fjrccaccess%2Fautoconfigure%2Fplugins%2Fconsole%2FConsoleOutput.java

Not sure if this print has to stay as it is or not, but it has been replaced with a simple info log instead displaying the content.

## Review Request

@alexjoybc 