### PR TITLE
Add and update exception file tests

### DIFF
--- a/jrcc-access-spring-boot-autoconfigure/src/test/java/ca/bc/gov/open/jrccaccess/autoconfigure/config/exceptions/KnownHostFileNotDefinedExceptionTests.java
+++ b/jrcc-access-spring-boot-autoconfigure/src/test/java/ca/bc/gov/open/jrccaccess/autoconfigure/config/exceptions/KnownHostFileNotDefinedExceptionTests.java
@@ -1,0 +1,19 @@
+package ca.bc.gov.open.jrccaccess.autoconfigure.config.exceptions;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class KnownHostFileNotDefinedExceptionTests {
+
+
+    @Test
+    public void constructor_with_message_should_create_a_new_exception() {
+
+        KnownHostFileNotDefinedException sut = new KnownHostFileNotDefinedException("not defined");
+
+        assertEquals("not defined", sut.getMessage());
+
+    }
+
+}

--- a/jrcc-access-spring-boot-autoconfigure/src/test/java/ca/bc/gov/open/jrccaccess/autoconfigure/config/exceptions/KnownHostFileNotFoundExceptionTests.java
+++ b/jrcc-access-spring-boot-autoconfigure/src/test/java/ca/bc/gov/open/jrccaccess/autoconfigure/config/exceptions/KnownHostFileNotFoundExceptionTests.java
@@ -1,0 +1,19 @@
+package ca.bc.gov.open.jrccaccess.autoconfigure.config.exceptions;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class KnownHostFileNotFoundExceptionTests {
+
+
+    @Test
+    public void constructor_with_message_should_create_a_new_exception() {
+
+        KnownHostFileNotFoundException sut = new KnownHostFileNotFoundException("not found");
+
+        assertEquals("not found", sut.getMessage());
+
+    }
+
+}

--- a/jrcc-document-access-libs/src/test/java/ca/bc/gov/open/jrccaccess/libs/services/exceptions/DocumentDigestMatchFailedExceptionTests.java
+++ b/jrcc-document-access-libs/src/test/java/ca/bc/gov/open/jrccaccess/libs/services/exceptions/DocumentDigestMatchFailedExceptionTests.java
@@ -1,0 +1,30 @@
+package ca.bc.gov.open.jrccaccess.libs.services.exceptions;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class DocumentDigestMatchFailedExceptionTests {
+
+
+    @Test
+    public void constructor_with_message_should_create_a_new_exception() {
+
+        DocumentDigestMatchFailedException sut = new DocumentDigestMatchFailedException("match failed");
+
+        assertEquals("match failed", sut.getMessage());
+
+    }
+
+    @Test
+    public void constructor_with_message_and_cause_should_create_a_new_exception(){
+
+        DocumentDigestMatchFailedException sut = new DocumentDigestMatchFailedException("match failed", new RuntimeException());
+
+        assertEquals("match failed", sut.getMessage());
+        assertEquals(RuntimeException.class, sut.getCause().getClass());
+
+    }
+
+
+}

--- a/jrcc-document-access-libs/src/test/java/ca/bc/gov/open/jrccaccess/libs/services/exceptions/DocumentFilenameMissingExceptionTests.java
+++ b/jrcc-document-access-libs/src/test/java/ca/bc/gov/open/jrccaccess/libs/services/exceptions/DocumentFilenameMissingExceptionTests.java
@@ -1,0 +1,30 @@
+package ca.bc.gov.open.jrccaccess.libs.services.exceptions;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class DocumentFilenameMissingExceptionTests {
+
+
+    @Test
+    public void constructor_with_message_should_create_a_new_exception() {
+
+        DocumentFilenameMissingException sut = new DocumentFilenameMissingException("filename missing");
+
+        assertEquals("filename missing", sut.getMessage());
+
+    }
+
+    @Test
+    public void constructor_with_message_and_cause_should_create_a_new_exception(){
+
+        DocumentFilenameMissingException sut = new DocumentFilenameMissingException("filename missing", new RuntimeException());
+
+        assertEquals("filename missing", sut.getMessage());
+        assertEquals(RuntimeException.class, sut.getCause().getClass());
+
+    }
+
+
+}

--- a/jrcc-document-access-libs/src/test/java/ca/bc/gov/open/jrccaccess/libs/services/exceptions/DocumentMessageExceptionTests.java
+++ b/jrcc-document-access-libs/src/test/java/ca/bc/gov/open/jrccaccess/libs/services/exceptions/DocumentMessageExceptionTests.java
@@ -1,0 +1,39 @@
+package ca.bc.gov.open.jrccaccess.libs.services.exceptions;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class DocumentMessageExceptionTests {
+
+
+    @Test
+    public void constructor_should_create_a_new_exception() {
+
+        DocumentMessageException sut = new DocumentMessageException();
+
+        assertEquals(null, sut.getMessage());
+
+    }
+
+    @Test
+    public void constructor_with_message_should_create_a_new_exception() {
+
+        DocumentMessageException sut = new DocumentMessageException("message exception");
+
+        assertEquals("message exception", sut.getMessage());
+
+    }
+
+    @Test
+    public void constructor_with_message_and_cause_should_create_a_new_exception(){
+
+        DocumentMessageException sut = new DocumentMessageException("message exception", new RuntimeException());
+
+        assertEquals("message exception", sut.getMessage());
+        assertEquals(RuntimeException.class, sut.getCause().getClass());
+
+    }
+
+
+}

--- a/jrcc-document-access-libs/src/test/java/ca/bc/gov/open/jrccaccess/libs/services/exceptions/DocumentNotFoundExceptionTests.java
+++ b/jrcc-document-access-libs/src/test/java/ca/bc/gov/open/jrccaccess/libs/services/exceptions/DocumentNotFoundExceptionTests.java
@@ -4,7 +4,7 @@ import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 
-public class DocumentNotFoundExceptionTester {
+public class DocumentNotFoundExceptionTests {
 
 
     @Test


### PR DESCRIPTION
## Overview

This PR addresses a few different sonarqube issues:

1) https://sonarqube-9wbi3f-tools.pathfinder.gov.bc.ca/component_measures?id=ca.bc.gov.open%3Adocument-access&metric=coverage&selected=ca.bc.gov.open%3Ajrcc-access-spring-boot-autoconfigure%3Asrc%2Fmain%2Fjava%2Fca%2Fbc%2Fgov%2Fopen%2Fjrccaccess%2Fautoconfigure%2Fconfig%2Fexceptions%2FKnownHostFileNotDefinedException.java

2) https://sonarqube-9wbi3f-tools.pathfinder.gov.bc.ca/component_measures?id=ca.bc.gov.open%3Adocument-access&metric=coverage&selected=ca.bc.gov.open%3Ajrcc-access-spring-boot-autoconfigure%3Asrc%2Fmain%2Fjava%2Fca%2Fbc%2Fgov%2Fopen%2Fjrccaccess%2Fautoconfigure%2Fconfig%2Fexceptions%2FKnownHostFileNotFoundException.java

3) https://sonarqube-9wbi3f-tools.pathfinder.gov.bc.ca/component_measures?id=ca.bc.gov.open%3Adocument-access&metric=coverage&selected=ca.bc.gov.open%3Ajrcc-document-access-libs%3Asrc%2Fmain%2Fjava%2Fca%2Fbc%2Fgov%2Fopen%2Fjrccaccess%2Flibs%2Fservices%2Fexceptions%2FDocumentDigestMatchFailedException.java

4) https://sonarqube-9wbi3f-tools.pathfinder.gov.bc.ca/component_measures?id=ca.bc.gov.open%3Adocument-access&metric=coverage&selected=ca.bc.gov.open%3Ajrcc-document-access-libs%3Asrc%2Fmain%2Fjava%2Fca%2Fbc%2Fgov%2Fopen%2Fjrccaccess%2Flibs%2Fservices%2Fexceptions%2FDocumentFilenameMissingException.java

5) https://sonarqube-9wbi3f-tools.pathfinder.gov.bc.ca/component_measures?id=ca.bc.gov.open%3Adocument-access&metric=coverage&selected=ca.bc.gov.open%3Ajrcc-document-access-libs%3Asrc%2Fmain%2Fjava%2Fca%2Fbc%2Fgov%2Fopen%2Fjrccaccess%2Flibs%2Fservices%2Fexceptions%2FDocumentNotFoundException.java

6) https://sonarqube-9wbi3f-tools.pathfinder.gov.bc.ca/component_measures?id=ca.bc.gov.open%3Adocument-access&metric=coverage&selected=ca.bc.gov.open%3Ajrcc-document-access-libs%3Asrc%2Fmain%2Fjava%2Fca%2Fbc%2Fgov%2Fopen%2Fjrccaccess%2Flibs%2Fservices%2Fexceptions%2FDocumentMessageException.java

## Note

I have changed the test file suffix from `Tester.java` to `Tests.java` so that surefire (mvn plugin) can pick up the tests and run them on every build. This should allow SonarQube to notice the tests and resolve these complaints.

## Review Requests

@alexjoybc @peggy-ntt 