### PR TITLE
Missing test cases SftpInputProperties

### DIFF
--- a/jrcc-access-spring-boot-autoconfigure/src/test/java/ca/bc/gov/open/jrccaccess/autoconfigure/plugins/sftp/SftpInputPropertiesTests.java
+++ b/jrcc-access-spring-boot-autoconfigure/src/test/java/ca/bc/gov/open/jrccaccess/autoconfigure/plugins/sftp/SftpInputPropertiesTests.java
@@ -101,6 +101,24 @@ public class SftpInputPropertiesTests {
     }
 
     @Test
+    public void default_get_host_returns_localhost() {
+        SftpInputProperties sut = new SftpInputProperties();
+        Assert.assertEquals(sut.getHost(), "localhost");
+    }
+
+    @Test
+    public void default_get_port_returns_22() {
+        SftpInputProperties sut = new SftpInputProperties();
+        Assert.assertEquals(sut.getPort(), Integer.valueOf("22"));
+    }
+
+    @Test
+    public void default_get_filter_pattern_returns_empty_string() {
+        SftpInputProperties sut = new SftpInputProperties();
+        Assert.assertEquals(sut.getFilterPattern(), "");
+    }
+
+    @Test
     public void set_known_hosts_should_succeed() {
         SftpInputProperties sut = new SftpInputProperties();
         sut.setKnownHostFile("c://test//known_hosts");


### PR DESCRIPTION
## Overview

This PR addresses the remaining sonarqube issues in this file (sftpinputproperties):

https://sonarqube-9wbi3f-tools.pathfinder.gov.bc.ca/component_measures?id=ca.bc.gov.open%3Adocument-access&metric=coverage&selected=ca.bc.gov.open%3Ajrcc-access-spring-boot-autoconfigure%3Asrc%2Fmain%2Fjava%2Fca%2Fbc%2Fgov%2Fopen%2Fjrccaccess%2Fautoconfigure%2Fplugins%2Fsftp%2FSftpInputProperties.java

It is because there were no tests explicitly testing the null conditions of these getters - this PR adds those in to remove the complaint.

## Review Requests

@alexjoybc @peggy-ntt 