### PR TITLE
Add InputConfig test case

### DIFF
--- a/jrcc-access-spring-boot-autoconfigure/src/test/java/ca/bc/gov/open/jrccaccess/autoconfigure/AccessAutoConfigurationTests.java
+++ b/jrcc-access-spring-boot-autoconfigure/src/test/java/ca/bc/gov/open/jrccaccess/autoconfigure/AccessAutoConfigurationTests.java
@@ -6,6 +6,7 @@ import ca.bc.gov.open.jrccaccess.autoconfigure.config.exceptions.OutputConfigMis
 import org.junit.Test;
 
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertEquals;
 
 
 public class AccessAutoConfigurationTests {
@@ -34,5 +35,14 @@ public class AccessAutoConfigurationTests {
         properties.setInput(new AccessProperties.PluginConfig());
         properties.setOutput(null);
         aac = new AccessAutoConfiguration(properties);
+    }
+
+    @Test
+    public void input_config_returns_valid_input_plugin_config() throws InvalidConfigException {
+        AccessProperties properties = new AccessProperties();
+        properties.setInput(new AccessProperties.PluginConfig());
+        properties.setOutput(new AccessProperties.PluginConfig());
+        aac = new AccessAutoConfiguration(properties);
+        assertEquals(aac.inputConfig(), properties.getInput());
     }
 }

--- a/jrcc-access-spring-boot-autoconfigure/src/test/java/ca/bc/gov/open/jrccaccess/autoconfigure/AccessAutoConfigurationTests.java
+++ b/jrcc-access-spring-boot-autoconfigure/src/test/java/ca/bc/gov/open/jrccaccess/autoconfigure/AccessAutoConfigurationTests.java
@@ -10,15 +10,15 @@ import static org.junit.Assert.assertEquals;
 
 
 public class AccessAutoConfigurationTests {
-    private AccessAutoConfiguration aac;
+    private AccessAutoConfiguration sut;
 
     @Test
     public void constructor_with_valid_property_should_create_object() throws Exception{
         AccessProperties properties = new AccessProperties();
         properties.setInput(new AccessProperties.PluginConfig());
         properties.setOutput(new AccessProperties.PluginConfig());
-        aac = new AccessAutoConfiguration(properties);
-        assertNotNull(aac );
+        sut = new AccessAutoConfiguration(properties);
+        assertNotNull(sut );
     }
 
     @Test(expected = InputConfigMissingException.class)
@@ -26,7 +26,7 @@ public class AccessAutoConfigurationTests {
         AccessProperties properties = new AccessProperties();
         properties.setOutput(new AccessProperties.PluginConfig());
         properties.setInput(null);
-        aac = new AccessAutoConfiguration(properties);
+        sut = new AccessAutoConfiguration(properties);
     }
 
     @Test(expected = OutputConfigMissingException.class)
@@ -34,7 +34,7 @@ public class AccessAutoConfigurationTests {
         AccessProperties properties = new AccessProperties();
         properties.setInput(new AccessProperties.PluginConfig());
         properties.setOutput(null);
-        aac = new AccessAutoConfiguration(properties);
+        sut = new AccessAutoConfiguration(properties);
     }
 
     @Test
@@ -42,7 +42,7 @@ public class AccessAutoConfigurationTests {
         AccessProperties properties = new AccessProperties();
         properties.setInput(new AccessProperties.PluginConfig());
         properties.setOutput(new AccessProperties.PluginConfig());
-        aac = new AccessAutoConfiguration(properties);
-        assertEquals(aac.inputConfig(), properties.getInput());
+        sut = new AccessAutoConfiguration(properties);
+        assertEquals(sut.inputConfig(), properties.getInput());
     }
 }


### PR DESCRIPTION
## Overview

This PR addresses the following sonarqube issue:
https://sonarqube-9wbi3f-tools.pathfinder.gov.bc.ca/component_measures?id=ca.bc.gov.open%3Adocument-access&metric=coverage&selected=ca.bc.gov.open%3Ajrcc-access-spring-boot-autoconfigure%3Asrc%2Fmain%2Fjava%2Fca%2Fbc%2Fgov%2Fopen%2Fjrccaccess%2Fautoconfigure%2FAccessAutoConfiguration.java

## Review Requested

@alexjoybc @peggy-ntt 