### PR TITLE
Add AccessAutoConfiguration tests

### DIFF
--- a/jrcc-access-spring-boot-autoconfigure/src/test/java/ca/bc/gov/open/jrccaccess/autoconfigure/AccessPropertiesTests.java
+++ b/jrcc-access-spring-boot-autoconfigure/src/test/java/ca/bc/gov/open/jrccaccess/autoconfigure/AccessPropertiesTests.java
@@ -1,0 +1,49 @@
+package ca.bc.gov.open.jrccaccess.autoconfigure;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import ca.bc.gov.open.jrccaccess.autoconfigure.common.Constants;
+import ca.bc.gov.open.jrccaccess.autoconfigure.AccessProperties;
+import ca.bc.gov.open.jrccaccess.autoconfigure.AccessProperties.PluginConfig;
+
+import static org.junit.Assert.assertEquals;
+
+public class AccessPropertiesTests {
+
+	@Test
+	public void with_sender_should_set_sender() {
+		String sender = "bcgov";
+
+        AccessProperties properties = new AccessProperties();
+        properties.setInput(new AccessProperties.PluginConfig());
+        PluginConfig pluginConfig = properties.getInput();
+
+		pluginConfig.setSender(sender);
+
+		assertEquals(pluginConfig.getSender(), sender);
+    }
+
+    @Test
+    public void with_no_explicit_sender_should_return_default() {
+        AccessProperties properties = new AccessProperties();
+        properties.setInput(new AccessProperties.PluginConfig());
+        PluginConfig pluginConfig = properties.getInput();
+
+        assertEquals(pluginConfig.getSender(), Constants.UNKNOWN_SENDER);
+    }
+
+    @Test
+    public void with_plugin_should_set_plugin() {
+        String plugin = "sftp";
+
+        AccessProperties properties = new AccessProperties();
+        properties.setInput(new AccessProperties.PluginConfig());
+        PluginConfig pluginConfig = properties.getInput();
+
+		pluginConfig.setPlugin(plugin);
+
+		assertEquals(pluginConfig.getPlugin(), plugin);
+    }
+
+}


### PR DESCRIPTION
## Overview

This PR addresses the following SonarQube issue:

https://sonarqube-9wbi3f-tools.pathfinder.gov.bc.ca/code?id=ca.bc.gov.open%3Adocument-access&selected=ca.bc.gov.open%3Ajrcc-access-spring-boot-autoconfigure%3Asrc%2Fmain%2Fjava%2Fca%2Fbc%2Fgov%2Fopen%2Fjrccaccess%2Fautoconfigure%2FAccessProperties.java

## Review

@alexjoybc @peggy-ntt 