### PR TITLE
Add precommit hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -554,3 +554,13 @@ mvn versions:set -DartifactId=*  -DgroupId=*
 it will prompt you for the new version
 
 do a pull request against dev
+
+### Contributing to the repository
+
+To contribute to the repo, please fork the repository and submit a pull request to the team. We will look into it accordingly.
+
+This project has been configured to use git hooks; specifically the precommit hook. Thus, on every commit the `mvn clean install` command will be executed which will run all your tests and ensure that your code successfully builds and compiles. This helps to ensure bug-free development and deployment.
+
+To set up the hooks to work, please run the following command from the root of the repo:
+
+`bash ./scripts/install-hooks.bash`

--- a/scripts/install-hooks.bash
+++ b/scripts/install-hooks.bash
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+GIT_DIR=$(git rev-parse --git-dir)
+
+echo "Installing hooks..."
+# this command creates symlink to our pre-commit script
+ln -s ../../scripts/pre-commit.bash $GIT_DIR/hooks/pre-commit
+echo "Done!

--- a/scripts/pre-commit.bash
+++ b/scripts/pre-commit.bash
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# save the file as <git_directory>/.git/hooks/pre-commit
+
+echo "Running Maven clean installl for build errors"
+# retrieving current working directory
+CWD=`pwd`
+MAIN_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+# go to main project dir
+cd $MAIN_DIR/../../
+# running maven clean install
+mvn clean install
+if [ $? -ne 0 ]; then
+  "Error while testing the code"
+  # go back to current working dir
+  cd $CWD
+  exit 1
+fi
+# go back to current working dir
+cd $CWD

--- a/scripts/pre-commit.bash
+++ b/scripts/pre-commit.bash
@@ -2,7 +2,7 @@
 
 # save the file as <git_directory>/.git/hooks/pre-commit
 
-echo "Running Maven clean installl for build errors"
+echo "Running Maven clean install for build errors"
 # retrieving current working directory
 CWD=`pwd`
 MAIN_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"

--- a/scripts/run-tests.bash
+++ b/scripts/run-tests.bash
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+# if any command inside script returns error, exit and return that error 
+set -e
+
+# magic line to ensure that we're always inside the root of our application,
+# no matter from which directory we'll run script
+# thanks to it we can just enter `./scripts/run-tests.bash`
+cd "${0%/*}/.."
+
+# let's fake failing test for now 
+echo "Running tests"
+echo "............................" 
+echo "Failed!" && exit 1


### PR DESCRIPTION
## Overview

This PR adds a precommit git hook so a `mvn clean install` command is executed on every commit to the repo. This way, before a push we can ensure that the code passes and is not going to cause a failing build.

If there are failures, then the commit will not be successful - this way you cannot commit code to remote repo until builds pass 😃 :shipit: 

## Installation

To get this working locally, you should just have to run the following command from the root of the directory:

`bash ./scripts/install-hooks.bash`

## Screenshots

### Passing case
<img width="500" alt="precommithook" src="https://user-images.githubusercontent.com/28017034/65362091-fdcd4900-dbba-11e9-96ea-00fb861c5de0.PNG">

### Failing case
<img width="948" alt="failurecase" src="https://user-images.githubusercontent.com/28017034/65362299-b5faf180-dbbb-11e9-9895-f595df8c1458.PNG">

## Review Requested

@alexjoybc @peggy-ntt 
