### PR TITLE
Add to Storage Service Interface

### DIFF
--- a/jrcc-access-spring-boot-autoconfigure/src/main/java/ca/bc/gov/open/jrccaccess/autoconfigure/plugins/rabbitmq/RabbitMqDocumentInput.java
+++ b/jrcc-access-spring-boot-autoconfigure/src/main/java/ca/bc/gov/open/jrccaccess/autoconfigure/plugins/rabbitmq/RabbitMqDocumentInput.java
@@ -5,6 +5,7 @@ import ca.bc.gov.open.jrccaccess.autoconfigure.redis.RedisStorageService;
 import ca.bc.gov.open.jrccaccess.autoconfigure.services.DocumentReadyHandler;
 import ca.bc.gov.open.jrccaccess.libs.DocumentReadyMessage;
 import ca.bc.gov.open.jrccaccess.libs.DocumentStorageProperties;
+import ca.bc.gov.open.jrccaccess.libs.StorageService;
 import ca.bc.gov.open.jrccaccess.libs.services.exceptions.DocumentMessageException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -27,16 +28,16 @@ public class RabbitMqDocumentInput {
 
 	private DocumentReadyHandler documentReadyHandler;
 
-	private final RedisStorageService redisStorageService;
+	private final StorageService storageService;
 
 	/**
 	 * Creates a RabbitMqDocumentInput.
 	 * 
 	 * @param documentReadyHandler - A document ready handler.
 	 */
-	public RabbitMqDocumentInput(DocumentReadyHandler documentReadyHandler, RedisStorageService redisStorageService) {
+	public RabbitMqDocumentInput(DocumentReadyHandler documentReadyHandler, StorageService storageService) {
 		this.documentReadyHandler = documentReadyHandler;
-		this.redisStorageService = redisStorageService;
+		this.storageService = storageService;
 	}
 
 	/**
@@ -54,7 +55,7 @@ public class RabbitMqDocumentInput {
 
 		DocumentStorageProperties storageProperties = documentReadyMessage.getDocumentStorageProperties();
 		
-		String content = this.redisStorageService.getString(storageProperties.getKey(), storageProperties.getDigest());
+		String content = this.storageService.getString(storageProperties.getKey(), storageProperties.getDigest());
 		
 		if (logger.isDebugEnabled()) {
 			logger.debug(content);
@@ -65,7 +66,7 @@ public class RabbitMqDocumentInput {
         logger.debug("attempting to delete the document from redis storage");
 
         //when successfully processed, delete the document from redis storage
-        this.redisStorageService.deleteString(storageProperties.getKey());
+        this.storageService.deleteString(storageProperties.getKey());
 
         logger.info("document successfully deleted from redis storage");
 		logger.info("message successfully acknowledged");

--- a/jrcc-access-spring-boot-autoconfigure/src/main/java/ca/bc/gov/open/jrccaccess/autoconfigure/plugins/rabbitmq/RabbitMqDocumentOutput.java
+++ b/jrcc-access-spring-boot-autoconfigure/src/main/java/ca/bc/gov/open/jrccaccess/autoconfigure/plugins/rabbitmq/RabbitMqDocumentOutput.java
@@ -21,17 +21,17 @@ public class RabbitMqDocumentOutput implements DocumentOutput {
 
 	private Logger logger = LoggerFactory.getLogger(RabbitMqDocumentOutput.class);
 	
-	private final RedisStorageService redisStorageService;
+	private final StorageService storageService;
 	private final RabbitMqDocumentReadyService rabbitMqDocumentReadyService;
 	private final AccessProperties accessProperties;
 	
 	/**
 	 * Constructs a rabbitMq Document Output Service.
-	 * @param redisStorageService	A {@link RedisStorageService}
+	 * @param storageService	A {@link StorageService}
 	 * @param rabbitMqDocumentReadyService	A {@link RabbitMqDocumentReadyService}
 	 */
-	public RabbitMqDocumentOutput(RedisStorageService redisStorageService, RabbitMqDocumentReadyService rabbitMqDocumentReadyService, AccessProperties accessProperties) {
-		this.redisStorageService = redisStorageService;
+	public RabbitMqDocumentOutput(StorageService storageService, RabbitMqDocumentReadyService rabbitMqDocumentReadyService, AccessProperties accessProperties) {
+		this.storageService = storageService;
 		this.rabbitMqDocumentReadyService = rabbitMqDocumentReadyService;
 		this.accessProperties = accessProperties;
 	}
@@ -47,7 +47,7 @@ public class RabbitMqDocumentOutput implements DocumentOutput {
 		logger.info("Attempting to publish [{}].", documentInfo);
 
 		logger.debug("Attempting to store [{}] to redis.", documentInfo);
-		DocumentStorageProperties documentStorageProperties = this.redisStorageService.putString(content);
+		DocumentStorageProperties documentStorageProperties = this.storageService.putString(content);
 		logger.info("[{}] successfully stored to redis key [{}].", documentInfo, documentStorageProperties.getKey());
 		
 		logger.debug("Creating new document ready message.");

--- a/jrcc-access-spring-boot-autoconfigure/src/main/java/ca/bc/gov/open/jrccaccess/autoconfigure/redis/RedisStorageService.java
+++ b/jrcc-access-spring-boot-autoconfigure/src/main/java/ca/bc/gov/open/jrccaccess/autoconfigure/redis/RedisStorageService.java
@@ -98,6 +98,7 @@ public class RedisStorageService implements StorageService {
 	 * @param key
 	 * @return
 	 */
+	@Override
 	public Boolean deleteString(String key) throws DocumentMessageException {
 
 		try {

--- a/jrcc-access-spring-boot-autoconfigure/src/test/java/ca/bc/gov/open/jrccaccess/autoconfigure/plugins/rabbitmq/RabbitMqDocumentInputTests.java
+++ b/jrcc-access-spring-boot-autoconfigure/src/test/java/ca/bc/gov/open/jrccaccess/autoconfigure/plugins/rabbitmq/RabbitMqDocumentInputTests.java
@@ -6,6 +6,7 @@ import ca.bc.gov.open.jrccaccess.autoconfigure.redis.RedisStorageService;
 import ca.bc.gov.open.jrccaccess.autoconfigure.services.DocumentReadyHandler;
 import ca.bc.gov.open.jrccaccess.libs.DocumentReadyMessage;
 import ca.bc.gov.open.jrccaccess.libs.DocumentStorageProperties;
+import ca.bc.gov.open.jrccaccess.libs.StorageService;
 import ca.bc.gov.open.jrccaccess.libs.TransactionInfo;
 import ca.bc.gov.open.jrccaccess.libs.services.exceptions.DocumentDigestMatchFailedException;
 import ca.bc.gov.open.jrccaccess.libs.services.exceptions.DocumentMessageException;
@@ -41,7 +42,7 @@ public class RabbitMqDocumentInputTests {
 	private TransactionInfo transactionInfoMock;
 	
 	@Mock
-	private RedisStorageService storageService;
+	private StorageService storageService;
 
 	@Before
 	public void init() throws Exception {
@@ -129,8 +130,6 @@ public class RabbitMqDocumentInputTests {
 		Mockito.when(this.transactionInfoMock.getSender()).thenReturn("bcgov");
 		Mockito.when(this.message.getTransactionInfo()).thenReturn(transactionInfoMock);
 		Mockito.when(this.message.getDocumentStorageProperties()).thenReturn(storageProperties);
-
-
 		
 		TransactionInfo transactionInfo = new TransactionInfo("testfile.txt", "me", LocalDateTime.now());
 

--- a/jrcc-access-spring-boot-autoconfigure/src/test/java/ca/bc/gov/open/jrccaccess/autoconfigure/plugins/rabbitmq/RabbitMqDocumentOutputTests.java
+++ b/jrcc-access-spring-boot-autoconfigure/src/test/java/ca/bc/gov/open/jrccaccess/autoconfigure/plugins/rabbitmq/RabbitMqDocumentOutputTests.java
@@ -4,6 +4,7 @@ import ca.bc.gov.open.jrccaccess.autoconfigure.AccessProperties;
 import ca.bc.gov.open.jrccaccess.autoconfigure.AccessProperties.PluginConfig;
 import ca.bc.gov.open.jrccaccess.autoconfigure.redis.RedisStorageService;
 import ca.bc.gov.open.jrccaccess.libs.DocumentStorageProperties;
+import ca.bc.gov.open.jrccaccess.libs.StorageService;
 import ca.bc.gov.open.jrccaccess.libs.TransactionInfo;
 import org.junit.Before;
 import org.junit.Test;
@@ -22,7 +23,7 @@ public class RabbitMqDocumentOutputTests {
 	private RabbitMqDocumentReadyService documentReadyService;
 	
 	@Mock
-	private RedisStorageService storageService;
+	private StorageService storageService;
 	
 	@Before
 	public void init() throws Exception {

--- a/jrcc-document-access-libs/src/main/java/ca/bc/gov/open/jrccaccess/libs/StorageService.java
+++ b/jrcc-document-access-libs/src/main/java/ca/bc/gov/open/jrccaccess/libs/StorageService.java
@@ -24,5 +24,11 @@ public interface StorageService {
 	 */
 	public String getString(String key, String digest) throws DocumentMessageException;
 
-
+	/**
+	 * Delete a document from storage based on the key
+	 * @param key
+	 * @return bool
+	 * @throws DocumentMessageException
+	 */
+	public Boolean deleteString(String key) throws DocumentMessageException;
 }


### PR DESCRIPTION
This is to address the issue:  Add to Storage Service Interface #162
add deleteString to Storage Service Interface
change redisStorageService in RabbitMqDocumentInput and RabbitMqDocumentOutput to use the StorageService interface

Please review. @alexjoybc  @sdevalapurkar  @TayGov 