### PR TITLE
Fixed issue with missing queues on master node

### DIFF
--- a/jrcc-access-spring-boot-autoconfigure/src/main/java/ca/bc/gov/open/jrccaccess/autoconfigure/plugins/rabbitmq/InputConfiguration.java
+++ b/jrcc-access-spring-boot-autoconfigure/src/main/java/ca/bc/gov/open/jrccaccess/autoconfigure/plugins/rabbitmq/InputConfiguration.java
@@ -118,6 +118,7 @@ public class InputConfiguration {
 		factory.setMessageConverter(messageConverter);
 		factory.setAfterReceivePostProcessors(documentInputPreProcessor);
 		factory.setErrorHandler(documentInputErrorHandler);
+		factory.setMissingQueuesFatal(false);
 		return factory;
 	}
 


### PR DESCRIPTION
This PR includes the following proposed change:

- [JUSTRCC-765] - https://justice.gov.bc.ca/jira/browse/JUSTRCC-765  

the following documentation explained the behavior:

[https://docs.spring.io/spring-amqp/api/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainer.html#setMissingQueuesFatal-boolean-](https://docs.spring.io/spring-amqp/api/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainer.html#setMissingQueuesFatal-boolean-)

With this flag set to false, then the container (rabbit simple container) will reconnect to the queue, this would solve the issue with losing the rabbitmq master node on rabbit.

I also found this on google:

[https://groups.google.com/forum/#!topic/rabbitmq-users/QqYk3HXoyrQ](https://groups.google.com/forum/#!topic/rabbitmq-users/QqYk3HXoyrQ)
