### PR TITLE
Fix SpringBoot3 autoconfiguration

### DIFF
--- a/jrcc-access-spring-boot-autoconfigure/src/main/resources/META-INF/spring.factories
+++ b/jrcc-access-spring-boot-autoconfigure/src/main/resources/META-INF/spring.factories
@@ -1,7 +1,0 @@
-org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-ca.bc.gov.open.jrccaccess.autoconfigure.AccessAutoConfiguration,\
-ca.bc.gov.open.jrccaccess.autoconfigure.redis.AutoConfiguration,\
-ca.bc.gov.open.jrccaccess.autoconfigure.plugins.rabbitmq.AutoConfiguration,\
-ca.bc.gov.open.jrccaccess.autoconfigure.plugins.console.AutoConfiguration,\
-ca.bc.gov.open.jrccaccess.autoconfigure.plugins.http.AutoConfiguration, \
-ca.bc.gov.open.jrccaccess.autoconfigure.plugins.sftp.AutoConfiguration

--- a/jrcc-access-spring-boot-autoconfigure/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/jrcc-access-spring-boot-autoconfigure/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,6 @@
+ca.bc.gov.open.jrccaccess.autoconfigure.AccessAutoConfiguration
+ca.bc.gov.open.jrccaccess.autoconfigure.redis.AutoConfiguration
+ca.bc.gov.open.jrccaccess.autoconfigure.plugins.rabbitmq.AutoConfiguration
+ca.bc.gov.open.jrccaccess.autoconfigure.plugins.console.AutoConfiguration
+ca.bc.gov.open.jrccaccess.autoconfigure.plugins.http.AutoConfiguration
+ca.bc.gov.open.jrccaccess.autoconfigure.plugins.sftp.AutoConfiguration


### PR DESCRIPTION
Moved spring.factories to the spring folder and renamed to org.springframework.boot.autoconfigure.AutoConfiguration.imports
