### PR TITLE
fix Caused by: java.lang.NullPointerException: Cannot invoke org.glas…

### DIFF
--- a/jrcc-access-api/pom.xml
+++ b/jrcc-access-api/pom.xml
@@ -40,6 +40,10 @@
 			<artifactId>jersey-media-json-jackson</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>org.glassfish.jersey.inject</groupId>
+			<artifactId>jersey-hk2</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>com.fasterxml.jackson.jaxrs</groupId>
 			<artifactId>jackson-jaxrs-base</artifactId>
 		</dependency>


### PR DESCRIPTION
…sfish.hk2.api.DynamicConfigurationService.createDynamicConfiguration()  because dcs is null